### PR TITLE
Remove server= mention from comments

### DIFF
--- a/modules/obras/produccion/view.py
+++ b/modules/obras/produccion/view.py
@@ -321,7 +321,7 @@ class ProduccionView(QWidget):
         from PyQt6.QtWidgets import QMessageBox
         QMessageBox.information(self, "Finalizar Etapa", "Acción de finalizar etapa ejecutada.")
 
-# NOTA: No debe haber credenciales ni cadenas de conexión hardcodeadas como 'server=' en este archivo. Usar variables de entorno o archivos de configuración seguros.
+# NOTA: Evitar credenciales o cadenas de conexión incrustadas de forma directa en este archivo.
 # Si necesitas una cadena de conexión, obténla de un archivo seguro o variable de entorno, nunca hardcodeada.
 # En los flujos de error, asegúrate de usar log_error y/o registrar_evento para cumplir el estándar de feedback visual y logging.
 

--- a/modules/pedidos/view.py
+++ b/modules/pedidos/view.py
@@ -343,6 +343,6 @@ class PedidosView(QWidget):
         btn_cancelar.clicked.connect(dialog.reject)
         dialog.exec()
 
-# NOTA: No debe haber credenciales ni cadenas de conexión hardcodeadas como 'server=' en este archivo. Usar variables de entorno o archivos de configuración seguros.
+# NOTA: Evitar credenciales o cadenas de conexión incrustadas de forma directa en este archivo.
 # Si necesitas una cadena de conexión, obténla de un archivo seguro o variable de entorno, nunca hardcodeada.
 # En los flujos de error, asegúrate de usar log_error y/o registrar_evento para cumplir el estándar de feedback visual y logging.


### PR DESCRIPTION
## Summary
- remove mention of the `server=` string in pedidos view comment
- remove mention of the `server=` string in produccion view comment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyodbc')*

------
https://chatgpt.com/codex/tasks/task_e_684739efd154832c9ec7711a816209c5