### PR TITLE
Add missing tests for Notificaciones and Configuracion modules

### DIFF
--- a/tests/configuracion/test_configuracion_view_feedback.py
+++ b/tests/configuracion/test_configuracion_view_feedback.py
@@ -1,0 +1,38 @@
+import unittest
+import pytest
+
+pd = pytest.importorskip("pandas")
+qt = pytest.importorskip("PyQt6")
+try:
+    from PyQt6.QtWidgets import QApplication
+except Exception as exc:  # pragma: no cover - skip if Qt libs missing
+    pytest.skip(f"PyQt6 unusable: {exc}", allow_module_level=True)
+from modules.configuracion.view import ConfiguracionView  # noqa: E402
+
+
+class TestConfiguracionViewFeedback(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if QApplication is None:
+            pytest.skip("PyQt6 not available")
+        cls.app = QApplication.instance() or QApplication([])
+
+    def setUp(self):
+        self.view = ConfiguracionView()
+
+    def test_mostrar_mensaje_sets_text_and_description(self):
+        self.view.mostrar_mensaje('ok', tipo='exito')
+        self.assertIn('ok', self.view.mensaje_label.text())
+        self.assertIn('exito', self.view.mensaje_label.accessibleDescription())
+
+    def test_mostrar_preview_handles_empty(self):
+        df = pd.DataFrame()
+        self.view.mostrar_preview(df)
+        self.assertEqual(self.view.preview_table.rowCount(), 0)
+        self.assertIn('vacío', self.view.mensaje_label.text().lower())
+
+    def test_mostrar_preview_populates_table(self):
+        df = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
+        self.view.mostrar_preview(df)
+        self.assertEqual(self.view.preview_table.rowCount(), 2)
+        self.assertTrue(self.view.boton_importar_csv.isEnabled())

--- a/tests/notificaciones/test_notificaciones_model.py
+++ b/tests/notificaciones/test_notificaciones_model.py
@@ -1,0 +1,33 @@
+import unittest
+from modules.notificaciones.model import NotificacionesModel
+
+
+class MockDB:
+    def __init__(self):
+        self.last_query = None
+        self.last_params = None
+        self.result = []
+
+    def ejecutar_query(self, query, params=None):
+        self.last_query = query
+        self.last_params = params
+        return self.result
+
+
+class TestNotificacionesModel(unittest.TestCase):
+    def setUp(self):
+        self.db = MockDB()
+        self.model = NotificacionesModel(self.db)
+
+    def test_obtener_notificaciones(self):
+        self.db.result = [(1, 'hola', '2025-06-09', 'info')]
+        result = self.model.obtener_notificaciones()
+        self.assertEqual(result, self.db.result)
+        self.assertIn('FROM notificaciones', self.db.last_query)
+        self.assertIsNone(self.db.last_params)
+
+    def test_agregar_notificacion(self):
+        datos = ('mensaje', '2025-06-10', 'info')
+        self.model.agregar_notificacion(datos)
+        self.assertIn('INSERT INTO notificaciones', self.db.last_query)
+        self.assertEqual(self.db.last_params, datos)


### PR DESCRIPTION
## Summary
- add unit tests for `NotificacionesModel`
- add feedback tests for `ConfiguracionView`
- skip tests if pandas isn't installed
- clean up formatting in new tests

## Testing
- `pytest tests/notificaciones/test_notificaciones_model.py tests/configuracion/test_configuracion_view_feedback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684741dc4e78832ca6931799c3f812f7